### PR TITLE
Fix: Adding '?' to valid password characters

### DIFF
--- a/dev/js/eventinator/eventSignupCtrl.js
+++ b/dev/js/eventinator/eventSignupCtrl.js
@@ -95,7 +95,7 @@ angular.module('eventinator').controller('eventSignupCtrl', ['$scope', '$locatio
 			upper: pwdVal.search(/[A-Z]/g) > -1,
 			lower: pwdVal.search(/[a-z]/g) > -1,
 			num: pwdVal.search(/[0-9]/g) > -1,
-			punct: pwdVal.search(/[!#$@&\*\_ \.]/g) > -1,
+			punct: pwdVal.search(/[!#$@\?&\*\_ \.]/g) > -1,
 			chars: pwdVal.length >= 8,
 			invalidChars: pwdVal.search(invalidChars) > -1
 		};


### PR DESCRIPTION
I accidentally omitted the '?' as a valid character in the password validation. I'm just adding that back in.